### PR TITLE
Don't misuse lua_next and avoid overflows

### DIFF
--- a/src/luaharfbuzz/buffer.c
+++ b/src/luaharfbuzz/buffer.c
@@ -84,16 +84,14 @@ static int buffer_add_codepoints(lua_State *L) {
   item_offset = luaL_optinteger(L, 3, 0);
   item_length = luaL_optinteger(L, 4, -1);
 
-  lua_len (L, 2);
-  unsigned int n = luaL_checkinteger(L, -1);
-  lua_pop(L, 1);
+  int n = lua_rawlen(L, 2);
 
   hb_codepoint_t *text = (hb_codepoint_t *) malloc(n * sizeof(hb_codepoint_t));
 
-  lua_pushnil(L); int i = 0;
-  while (lua_next(L, 2) != 0) {
+  for (unsigned int i = 0; i != n; ++i) {
+    lua_geti(L, 2, i + 1);
     hb_codepoint_t c = (hb_codepoint_t) luaL_checkinteger(L, -1);
-    text[i++] = c;
+    text[i] = c;
     lua_pop(L, 1);
   }
 

--- a/src/luaharfbuzz/luaharfbuzz.c
+++ b/src/luaharfbuzz/luaharfbuzz.c
@@ -1,7 +1,7 @@
 #include "luaharfbuzz.h"
 
 int shape_full (lua_State *L) {
-  int i = 0;
+  unsigned int i;
   Font *font = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
   Buffer *buf = (Buffer *)luaL_checkudata(L, 2, "harfbuzz.Buffer");
   luaL_checktype(L, 3, LUA_TTABLE);
@@ -10,21 +10,20 @@ int shape_full (lua_State *L) {
   unsigned int num_features = lua_rawlen(L, 3);
   Feature *features = (Feature *) malloc (num_features * sizeof(hb_feature_t));
 
-  lua_pushnil(L);
-  while (lua_next(L, 3) != 0) {
+  for (i = 0; i != num_features; ++i) {
+    lua_geti(L, 3, i + 1);
     Feature* f = (Feature *)luaL_checkudata(L, -1, "harfbuzz.Feature");
-    features[i++] = *f;
+    features[i] = *f;
     lua_pop(L, 1);
   }
 
   const char **shapers = NULL;
   size_t num_shapers = lua_rawlen(L, 4);
   if (num_shapers) {
-    i = 0;
     shapers = (const char**) calloc (num_shapers + 1, sizeof(char*));
-    lua_pushnil(L);
-    while (lua_next(L, 4) != 0) {
-      shapers[i++] = luaL_checkstring(L, -1);
+    for (i = 0; i != num_shapers; ++i) {
+      lua_geti(L, 4, i + 1);
+      shapers[i] = luaL_checkstring(L, -1);
       lua_pop(L, 1);
     }
   }

--- a/src/luaharfbuzz/luaharfbuzz.c
+++ b/src/luaharfbuzz/luaharfbuzz.c
@@ -1,7 +1,6 @@
 #include "luaharfbuzz.h"
 
 int shape_full (lua_State *L) {
-  unsigned int i;
   Font *font = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
   Buffer *buf = (Buffer *)luaL_checkudata(L, 2, "harfbuzz.Buffer");
   luaL_checktype(L, 3, LUA_TTABLE);
@@ -10,7 +9,7 @@ int shape_full (lua_State *L) {
   unsigned int num_features = lua_rawlen(L, 3);
   Feature *features = (Feature *) malloc (num_features * sizeof(hb_feature_t));
 
-  for (i = 0; i != num_features; ++i) {
+  for (unsigned int i = 0; i != num_features; ++i) {
     lua_geti(L, 3, i + 1);
     Feature* f = (Feature *)luaL_checkudata(L, -1, "harfbuzz.Feature");
     features[i] = *f;
@@ -21,7 +20,7 @@ int shape_full (lua_State *L) {
   size_t num_shapers = lua_rawlen(L, 4);
   if (num_shapers) {
     shapers = (const char**) calloc (num_shapers + 1, sizeof(char*));
-    for (i = 0; i != num_shapers; ++i) {
+    for (unsigned int i = 0; i != num_shapers; ++i) {
       lua_geti(L, 4, i + 1);
       shapers[i] = luaL_checkstring(L, -1);
       lua_pop(L, 1);


### PR DESCRIPTION
1. Using `lua_len` instead of `lua_rawlen` in buffer.c leads to more complicated code, is slower, is inconsistent with luaharfbuzz.c and leads to a security problem: The value returned by `lua_len` can be manipulated through Lua, so it can be set to a much lower value. Then the following loop writes past the end of the buffer, overwriting arbitrary data.
2. In multiple positions, the code uses `lua_next`  like
```
lua_pushnil(L); int i = 0;
while (lua_next(L, 2) != 0) {
  ... = luaL_checkinteger(L, -1);
  ...[i++] = ...;
  lua_pop(L, 1);
}
```
There are multiple issues with this: First, `lua_next` pushes two values (the key and the value), so when only one is pop'ed in the end, the key remains on the stack. Also this code assumes that the valued are returned in the canonical order. While this normally happens, it is not guaranteed: To quote the Lua reference manual (about `next`, but `lua_next` is just a C name for `next`):
> The order in which the indices are enumerated is not specified, *even for numeric indices*. (To traverse a table in numerical order, use a numerical **for**.) 

(It is also slightly slower than iterating over the indices directly.)
