### PR TITLE
Allow access and modification for Feature fields

### DIFF
--- a/spec/harfbuzz_spec.lua
+++ b/spec/harfbuzz_spec.lua
@@ -336,6 +336,30 @@ describe("harfbuzz module", function()
       local f = harfbuzz.Feature.new(fs)
       assert.are_equal(fs, tostring(f))
     end)
+
+    it("has visible fields", function()
+      local f = harfbuzz.Feature.new('-kern')
+      print(getmetatable(f).__index)
+      assert.are_equal(tostring(f.tag), 'kern')
+      assert.are_equal(f.value, 0)
+      assert.are_equal(f.start, nil)
+      assert.are_equal(f._end, nil)
+
+      f = harfbuzz.Feature.new('aalt[3:5]=4')
+      assert.are_equal(tostring(f.tag), 'aalt')
+      assert.are_equal(f.value, 4)
+      assert.are_equal(f.start, 3)
+      assert.are_equal(f._end, 5)
+    end)
+
+    it("has editable fields", function()
+      local f = harfbuzz.Feature.new('-kern')
+      f.tag, f.value, f.start, f._end = harfbuzz.Tag.new"aalt", 4, 3, 5
+      assert.are_equal(tostring(f), "aalt[3:5]=4")
+
+      f.tag, f.value, f.start, f._end = harfbuzz.Tag.new"harf", 0, nil, nil
+      assert.are_equal(tostring(f), "-harf")
+    end)
   end)
 
   describe("harfbuzz.Tag", function()

--- a/src/luaharfbuzz/feature.c
+++ b/src/luaharfbuzz/feature.c
@@ -26,7 +26,63 @@ static int feature_to_string(lua_State *L) {
   return 1;
 }
 
+static const char *feature_tag_ptr;
+static const char *feature_value_ptr;
+static const char *feature_start_ptr;
+static const char *feature_end_ptr;
+
+static int feature_index(lua_State *L) {
+  Feature* f = (Feature *)luaL_checkudata(L, 1, "harfbuzz.Feature");
+  const char *key = lua_tostring(L, 2);
+
+  if (key == feature_tag_ptr) {
+    Tag *tag = (Tag *)lua_newuserdata(L, sizeof(*tag));
+    luaL_getmetatable(L, "harfbuzz.Tag");
+    lua_setmetatable(L, -2);
+    *tag = f->tag;
+  } else if (key == feature_value_ptr) {
+    lua_pushinteger(L, f->value);
+  } else if (key == feature_start_ptr) {
+    if (f->start == HB_FEATURE_GLOBAL_START)
+      lua_pushnil(L);
+    else
+      lua_pushinteger(L, f->start);
+  } else if (key == feature_end_ptr) {
+    if (f->end == HB_FEATURE_GLOBAL_END)
+      lua_pushnil(L);
+    else
+      lua_pushinteger(L, f->end);
+  } else {
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
+static int feature_newindex(lua_State *L) {
+  Feature* f = (Feature *)luaL_checkudata(L, 1, "harfbuzz.Feature");
+  const char *key = lua_tostring(L, 2);
+
+  if (key == feature_tag_ptr) {
+    f->tag = *(Tag *)luaL_checkudata(L, 3, "harfbuzz.Tag");
+  } else if (key == feature_value_ptr) {
+    f->value = luaL_checkinteger(L, 3);
+  } else if (key == feature_start_ptr) {
+    if (lua_toboolean(L, 3))
+      f->start = luaL_checkinteger(L, 3);
+    else
+      f->start = HB_FEATURE_GLOBAL_START;
+  } else if (key == feature_end_ptr) {
+    if (lua_toboolean(L, 3))
+      f->end = luaL_checkinteger(L, 3);
+    else
+      f->end = HB_FEATURE_GLOBAL_END;
+  }
+  return 0;
+}
+
 static const struct luaL_Reg feature_methods[] = {
+  { "__index", feature_index },
+  { "__newindex", feature_newindex },
   { "__tostring", feature_to_string },
   { NULL, NULL },
 };
@@ -37,5 +93,18 @@ static const struct luaL_Reg feature_functions[] = {
 };
 
 int register_feature(lua_State *L) {
+  lua_pushliteral(L, "tag");
+  feature_tag_ptr = lua_tostring(L, -1);
+  (void) luaL_ref (L, LUA_REGISTRYINDEX);
+  lua_pushliteral(L, "value");
+  feature_value_ptr = lua_tostring(L, -1);
+  (void) luaL_ref (L, LUA_REGISTRYINDEX);
+  lua_pushliteral(L, "start");
+  feature_start_ptr = lua_tostring(L, -1);
+  (void) luaL_ref (L, LUA_REGISTRYINDEX);
+  lua_pushliteral(L, "_end"); /* _end instead of end to avoid Lua keyword */
+  feature_end_ptr = lua_tostring(L, -1);
+  (void) luaL_ref (L, LUA_REGISTRYINDEX);
+
   return register_class(L, "harfbuzz.Feature", feature_methods, feature_functions, NULL);
 }


### PR DESCRIPTION
Currently Features are handled as blackboxes which can only be created and analyzed through their string representation. I suggest to change that to expose their inner structure.
This makes is easier for code to create them automatically because their is no longer a need to rely on the structure of HarfBuzz's feature string syntax.

There are three implementation details worth mentioning:

 1. I suggest implementing modeling this as Lua table fields corresponding to the fields of HarfBuzz's `hb_feature_t` structure. In HarfBuzz, one field is named `.end`. I think it is better to rename this to `_end` to allow easier use from Lua (Then it can be accessed with the mmore natural `feat._end` instead of `feat["end"]`).
  2. If no bounds are set for some feature, Lua assigns special constants `HB_FEATURE_GLOBAL_START` and `HB_FEATURE_GLOBAL_END`. I suggest to model these using `nil` because this captures the idea not-existing bounds. For `.start`, this means that `0` will always appear as `nil` because it corresponds to `HB_FEATURE_GLOBAL_START`.
  3. You could argue that if access to individual fields is provided, there should also be a constructor which does not use the string representation but e.g. constructs an empty Feature to be filled later. While this could be added at a later stage, I think that the current approach has the merit that all fields have well-defined values at every stage. Therefore there is no problem with having undefined values after construction of an empty feature.