### PR TITLE
Add (single codepoint) "add" method to buffer

### DIFF
--- a/spec/buffer_spec.lua
+++ b/spec/buffer_spec.lua
@@ -5,6 +5,15 @@ describe("harfbuzz.Buffer", function()
     harfbuzz.Buffer.new()
   end)
 
+  it("can add a single codepoints with explicit cluster value", function()
+    local b = harfbuzz.Buffer.new()
+    b:add(0x06CC, 42)
+    local glyphs = b:get_glyphs()
+    assert.are_equal(#glyphs, 1)
+    assert.are_equal(glyphs[1].cluster, 42)
+    assert.are_equal(glyphs[1].codepoint, 0x06CC)
+  end)
+
   it("can add a UTF8 string", function()
     local b = harfbuzz.Buffer.new()
     local s = "Some String"

--- a/src/luaharfbuzz/buffer.c
+++ b/src/luaharfbuzz/buffer.c
@@ -123,6 +123,17 @@ static int buffer_set_replacement_codepoint(lua_State *L) {
   return 0;
 }
 
+static int buffer_add(lua_State *L) {
+  Buffer *b = (Buffer *)luaL_checkudata(L, 1, "harfbuzz.Buffer");
+
+  hb_codepoint_t c = (hb_codepoint_t) luaL_checkinteger(L, 2);
+  unsigned int cluster = luaL_checkinteger(L, 3);
+
+  hb_buffer_add(*b, c, cluster);
+
+  return 0;
+}
+
 static int buffer_add_codepoints(lua_State *L) {
   Buffer *b = (Buffer *)luaL_checkudata(L, 1, "harfbuzz.Buffer");
   unsigned int item_offset;
@@ -274,6 +285,7 @@ static int buffer_pre_allocate(lua_State *L) {
 
 static const struct luaL_Reg buffer_methods[] = {
   { "__gc", buffer_destroy },
+  { "add", buffer_add },
   { "add_utf8", buffer_add_utf8 },
   { "add_codepoints", buffer_add_codepoints },
   { "clear_contents", buffer_clear_contents },


### PR DESCRIPTION
Wrap `hb_buffer_add`. This allows to explicitly set the cluster number and therefore allows experiments with more flexible numbering.

A test is included