### PR TITLE
Provide interface for hb_style and font variation metrics

### DIFF
--- a/spec/harfbuzz_spec.lua
+++ b/spec/harfbuzz_spec.lua
@@ -396,11 +396,13 @@ describe("harfbuzz module", function()
       assert.are_same(1<<13, normalized)
     end)
 
-    it("allows querying style parameters", function()
-      local font = harfbuzz.Font.new(face)
-      local wght = font:style_get_value(harfbuzz.Tag.new"wght")
-      assert.are_equal(400, wght)
-    end)
+    if not harfbuzz:version():match'^2%.' then
+      it("allows querying style parameters", function()
+        local font = harfbuzz.Font.new(face)
+        local wght = font:style_get_value(harfbuzz.Tag.new"wght")
+        assert.are_equal(400, wght)
+      end)
+    end
 
     it("allows querying variation metrics", function()
       local f = harfbuzz.Font.new(harfbuzz.Face.new('fonts/STIXTwoText[wght].ttf'))

--- a/spec/harfbuzz_spec.lua
+++ b/spec/harfbuzz_spec.lua
@@ -395,6 +395,22 @@ describe("harfbuzz module", function()
       assert.is_nil(after)
       assert.are_same(1<<13, normalized)
     end)
+
+    it("allows querying style parameters", function()
+      local font = harfbuzz.Font.new(face)
+      local wght = font:style_get_value(harfbuzz.Tag.new"wght")
+      assert.are_equal(400, wght)
+    end)
+
+    it("allows querying variation metrics", function()
+      local f = harfbuzz.Font.new(harfbuzz.Face.new('fonts/STIXTwoText[wght].ttf'))
+      f:set_variations(harfbuzz.Variation.new("wght=500"))
+
+      local subscript_offset = f:ot_metrics_get_x_variation(harfbuzz.Tag.new"sbxo")
+      local cap_height = f:ot_metrics_get_y_variation(harfbuzz.Tag.new"cpht")
+      assert.are_equal(0, cap_height)
+      assert.are_equal(0, subscript_offset)
+    end)
   end)
 
   describe("harfbuzz.Feature", function()

--- a/src/luaharfbuzz/font.c
+++ b/src/luaharfbuzz/font.c
@@ -166,6 +166,17 @@ static int font_get_nominal_glyph(lua_State *L) {
   return 1;
 }
 
+#if HB_VERSION_MAJOR >= 3
+static int font_style_get_value(lua_State *L) {
+  Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
+  Tag *t = (Tag *)luaL_checkudata(L, 2, "harfbuzz.Tag");
+
+  lua_pushnumber(L, hb_style_get_value(*f, *t));
+
+  return 1;
+}
+#endif
+
 
 static int font_destroy(lua_State *L) {
   Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
@@ -188,6 +199,46 @@ static int font_ot_color_glyph_get_png(lua_State *L) {
   } else {
     lua_pushnil(L);
   }
+
+  return 1;
+}
+
+static int font_ot_metrics_get_position(lua_State *L) {
+  Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
+  Tag *t = (Tag *)luaL_checkudata(L, 2, "harfbuzz.Tag");
+  hb_position_t result;
+
+  if (hb_ot_metrics_get_position(*f, *t, &result))
+    lua_pushinteger(L, result);
+  else
+    lua_pushnil(L);
+
+  return 1;
+}
+
+static int font_ot_metrics_get_variation(lua_State *L) {
+  Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
+  Tag *t = (Tag *)luaL_checkudata(L, 2, "harfbuzz.Tag");
+
+  lua_pushnumber(L, hb_ot_metrics_get_variation(*f, *t));
+
+  return 1;
+}
+
+static int font_ot_metrics_get_x_variation(lua_State *L) {
+  Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
+  Tag *t = (Tag *)luaL_checkudata(L, 2, "harfbuzz.Tag");
+
+  lua_pushinteger(L, hb_ot_metrics_get_x_variation(*f, *t));
+
+  return 1;
+}
+
+static int font_ot_metrics_get_y_variation(lua_State *L) {
+  Font *f = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
+  Tag *t = (Tag *)luaL_checkudata(L, 2, "harfbuzz.Tag");
+
+  lua_pushinteger(L, hb_ot_metrics_get_y_variation(*f, *t));
 
   return 1;
 }
@@ -260,7 +311,14 @@ static const struct luaL_Reg font_methods[] = {
   { "get_glyph_h_advance", font_get_glyph_h_advance },
   { "get_glyph_v_advance", font_get_glyph_v_advance },
   { "get_nominal_glyph", font_get_nominal_glyph },
+#if HB_VERSION_MAJOR >= 3
+  { "style_get_value", font_style_get_value },
+#endif
   { "ot_color_glyph_get_png", font_ot_color_glyph_get_png },
+  { "ot_metrics_get_position", font_ot_metrics_get_position },
+  { "ot_metrics_get_variation", font_ot_metrics_get_variation },
+  { "ot_metrics_get_x_variation", font_ot_metrics_get_x_variation },
+  { "ot_metrics_get_y_variation", font_ot_metrics_get_y_variation },
   { "set_variations", font_set_variations },
   { "set_var_coords_design", font_set_var_coords_design },
   { "set_var_coords_normalized", font_set_var_coords_normalized },


### PR DESCRIPTION
Since HarfBuzz 3.0, hb-style is no longer experimental. It is a very useful interface to get some font metadata while automatically selecting between font variation based data if applicable and static fields otherwise.

Also adds a interface for `font_ot_metrics_get_variation` and friends to provide full access to font variation metrics if necessary.