### PR TITLE
Fix the luadoc documentation for the __tostring() functions

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -347,7 +347,7 @@
 	<td class="summary">Wraps <code>hb_tag_from_string</code>.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#Tag:__to_string">Tag:__to_string ()</a></td>
+	<td class="name" nowrap><a href="#Tag:__tostring">Tag:__tostring ()</a></td>
 	<td class="summary">Wraps <code>hb_tag_to_string</code>.</td>
 	</tr>
 	<tr>
@@ -370,7 +370,7 @@
 	<td class="summary">Wraps <code>hb_script_to_iso15924_tag</code>.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#Script:__to_string">Script:__to_string ()</a></td>
+	<td class="name" nowrap><a href="#Script:__tostring">Script:__tostring ()</a></td>
 	<td class="summary">Enable nice output with <code>tostring(…)</code></td>
 	</tr>
 	<tr>
@@ -404,7 +404,7 @@
 	<td class="summary">Wraps <code>hb_direction_from_string</code>.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#Direction:__to_string">Direction:__to_string ()</a></td>
+	<td class="name" nowrap><a href="#Direction:__tostring">Direction:__tostring ()</a></td>
 	<td class="summary">Wraps <code>hb_direction_to_string</code>.</td>
 	</tr>
 	<tr>
@@ -458,7 +458,7 @@
 	<td class="summary">Wraps <code>hb_language_from_string</code>.</td>
 	</tr>
 	<tr>
-	<td class="name" nowrap><a href="#Language:__to_string">Language:__to_string ()</a></td>
+	<td class="name" nowrap><a href="#Language:__tostring">Language:__tostring ()</a></td>
 	<td class="summary">Wraps <code>hb_language_to_string</code>.</td>
 	</tr>
 	<tr>
@@ -1831,8 +1831,8 @@
 
 </dd>
     <dt>
-    <a name = "Tag:__to_string"></a>
-    <strong>Tag:__to_string ()</strong>
+    <a name = "Tag:__tostring"></a>
+    <strong>Tag:__tostring ()</strong>
     </dt>
     <dd>
     Wraps <code>hb_tag_to_string</code>.  Enable nice output with <code>tostring(…)</code>.
@@ -1940,8 +1940,8 @@
 
 </dd>
     <dt>
-    <a name = "Script:__to_string"></a>
-    <strong>Script:__to_string ()</strong>
+    <a name = "Script:__tostring"></a>
+    <strong>Script:__tostring ()</strong>
     </dt>
     <dd>
     Enable nice output with <code>tostring(…)</code>
@@ -2073,8 +2073,8 @@
 
 </dd>
     <dt>
-    <a name = "Direction:__to_string"></a>
-    <strong>Direction:__to_string ()</strong>
+    <a name = "Direction:__tostring"></a>
+    <strong>Direction:__tostring ()</strong>
     </dt>
     <dd>
     Wraps <code>hb_direction_to_string</code>.  Enable nice output with <code>tostring(…)</code>.
@@ -2301,8 +2301,8 @@
 
 </dd>
     <dt>
-    <a name = "Language:__to_string"></a>
-    <strong>Language:__to_string ()</strong>
+    <a name = "Language:__tostring"></a>
+    <strong>Language:__tostring ()</strong>
     </dt>
     <dd>
     Wraps <code>hb_language_to_string</code>.  Enable nice output with <code>tostring(…)</code>.

--- a/src/harfbuzz.luadoc
+++ b/src/harfbuzz.luadoc
@@ -308,7 +308,7 @@
 
 --- Wraps `hb_tag_to_string`. Enable nice output with `tostring(…)`.
 -- @return Returns a string representation for the tag object.
--- @function Tag:__to_string
+-- @function Tag:__tostring
 
 --- Enables equality comparisions with `==` between two tags.
 -- @return `true` or `false` depending on whether the two tags are equal.
@@ -333,7 +333,7 @@
 
 --- Enable nice output with `tostring(…)`
 -- @return Returns a 4-letter [ISO 15924 script code](http://www.unicode.org/iso15924/iso15924-num.html) for the script object.
--- @function Script:__to_string
+-- @function Script:__tostring
 
 --- Enables equality comparisions with `==` between two scripts.
 -- @return `true` or `false` depending on whether the two scripts are equal.
@@ -365,7 +365,7 @@
 
 --- Wraps `hb_direction_to_string`. Enable nice output with `tostring(…)`.
 -- @return Returns a string representation for direction.
--- @function Direction:__to_string
+-- @function Direction:__tostring
 
 --- Enables equality comparisions with `==` between two directions.
 -- @return `true` or `false` depending on whether the two tags are equal.
@@ -417,7 +417,7 @@
 
 --- Wraps `hb_language_to_string`. Enable nice output with `tostring(…)`.
 -- @return Returns a string representation for the language object.
--- @function Language:__to_string
+-- @function Language:__tostring
 
 --- Enables equality comparisions with `==` between two languages.
 -- @return `true` or `false` depending on whether the two languages are equal.


### PR DESCRIPTION
The functions are exported as __tostring() not __to_string()

See:

* https://github.com/ufyTeX/luaharfbuzz/blob/b3bdf5dc7a6e3f9b674226140c3dfdc73d2970cd/src/luaharfbuzz/tag.c#L38
* https://github.com/ufyTeX/luaharfbuzz/blob/b3bdf5dc7a6e3f9b674226140c3dfdc73d2970cd/src/luaharfbuzz/direction.c#L67
* https://github.com/ufyTeX/luaharfbuzz/blob/b3bdf5dc7a6e3f9b674226140c3dfdc73d2970cd/src/luaharfbuzz/script.c#L57
* https://github.com/ufyTeX/luaharfbuzz/blob/b3bdf5dc7a6e3f9b674226140c3dfdc73d2970cd/src/luaharfbuzz/language.c#L37
