### PR TITLE
harfbuzz: fix duplicate symbols in static builds

### DIFF
--- a/src/luaharfbuzz/luaharfbuzz.c
+++ b/src/luaharfbuzz/luaharfbuzz.c
@@ -1,6 +1,6 @@
 #include "luaharfbuzz.h"
 
-int shape_full (lua_State *L) {
+static int shape_full (lua_State *L) {
   Font *font = (Font *)luaL_checkudata(L, 1, "harfbuzz.Font");
   Buffer *buf = (Buffer *)luaL_checkudata(L, 2, "harfbuzz.Buffer");
   luaL_checktype(L, 3, LUA_TTABLE);
@@ -36,12 +36,12 @@ int shape_full (lua_State *L) {
   return 1;
 }
 
-int version (lua_State *L) {
+static int version (lua_State *L) {
   lua_pushstring(L, hb_version_string());
   return 1;
 }
 
-int list_shapers (lua_State *L) {
+static int list_shapers (lua_State *L) {
   const char **shaper_list = hb_shape_list_shapers ();
   int i = 0;
 

--- a/src/luaharfbuzzsubset/luaharfbuzzsubset.c
+++ b/src/luaharfbuzzsubset/luaharfbuzzsubset.c
@@ -1,6 +1,6 @@
 #include "luaharfbuzzsubset.h"
 
-int subset(lua_State *L) {
+static int subset(lua_State *L) {
   // arguments: face and input
   Face *face = (Face *)luaL_checkudata(L, 1, "harfbuzz.Face");
   SubsetInput *input = (SubsetInput*)luaL_checkudata(L, 2, "harfbuzz.SubsetInput");
@@ -19,7 +19,7 @@ int subset(lua_State *L) {
   return 1;
 }
 
-int version (lua_State *L) {
+static int version (lua_State *L) {
   lua_pushstring(L, hb_version_string());
   return 1;
 }


### PR DESCRIPTION
This fixes #66 by declaring the functions as static.